### PR TITLE
set overscroll bg to match body background

### DIFF
--- a/src/app.html
+++ b/src/app.html
@@ -24,5 +24,8 @@
 	</head>
 	<body class="gruv:text-gray-100 text-gray-100 bg-gradient-to-r gruv:from-orange-800 gruv:to-yellow-800 from-neutral-900 to-slate-900">
 		<div id="svelte">%sveltekit.body%</div>
+    <div
+      class="fixed pointer-events-none w-full h-full top-0 left-0 -z-10 bg-gradient-to-r gruv:from-orange-800 gruv:to-yellow-800 from-neutral-900 to-slate-900"
+    ></div>
 	</body>
 </html>


### PR DESCRIPTION
before:


https://github.com/codicocodes/dotfyle/assets/31113245/a7650746-d803-4ee2-8d3b-4b2f6ae40321


after:

https://github.com/codicocodes/dotfyle/assets/31113245/ed913b03-1806-4cb3-b291-23794b7f8f79


I set a `position: fixed` element in the background because it's impossible to set `background-image: linear-gradient();` styles on `<html>` element, it only accepts `background-color`