### PR TITLE
Add MunifTanjim/nougat.nvim

### DIFF
--- a/SUBMITTED-PLUGINS.md
+++ b/SUBMITTED-PLUGINS.md
@@ -76,6 +76,8 @@
 
 ## Bars and Lines
 
+- MunifTanjim/nougat.nvim
+
 ## Statusline
 
 - echasnovski/mini.statusline


### PR DESCRIPTION
I introduced item priority feature to `nougat.nvim` at last: https://github.com/MunifTanjim/nougat.nvim/pull/39 and published `v0.2.0` https://github.com/MunifTanjim/nougat.nvim/releases/tag/0.2.0

Not sure how to publish it in TWIN. Is everything automated and I only need to update this single file? 🤔