### PR TITLE
Support case-insensitive search for `MultiSelectFilter`

### DIFF
--- a/src/lib/components/MultiSelectFilter.svelte
+++ b/src/lib/components/MultiSelectFilter.svelte
@@ -37,7 +37,7 @@
 	<div class="flex flex-wrap gap-1 text-xs mt-2">
 		{#each items
 			.filter((c) => (selected.size > 0 ? !selected.has(c) : true))
-			.filter((c) => c.includes(filter))
+			.filter((c) => c.toLowerCase().includes(filter.toLowerCase()))
 			.slice(0, expanded ? -1 : expandAtCount) as currItem}
 			<CoolTextOnHover>
 				<button


### PR DESCRIPTION
On mobile, by default, the first character is always capitalized which can be confusing. I _think_ this is a safe change for all `MultiSelectFilter` consumers.

Screenshot:
<img width="396" alt="image" src="https://github.com/codicocodes/dotfyle/assets/11138610/4ab2ed40-4a7c-4ee5-bbba-346009588d7e">
