### PR TITLE
Improving label on configuration for plugin section

### DIFF
--- a/src/lib/components/NeovimConfigMetaData.svelte
+++ b/src/lib/components/NeovimConfigMetaData.svelte
@@ -46,7 +46,7 @@
 				<div class="w-[20px]">
 					<Fa icon={faPuzzlePiece} />
 				</div>
-				plugins
+				plugins (detected)
 			</span>
 			<span class="flex items-center gap-1">
 				{#if syncing}

--- a/src/routes/[username]/[slug]/+page.svelte
+++ b/src/routes/[username]/[slug]/+page.svelte
@@ -131,7 +131,7 @@
 
 	<div class="flex flex-col w-full">
 		<div class="text-xl w-full flex justify-between items-center py-2">
-			<span class="font-semibold">Plugins</span>
+			<span class="font-semibold">Plugins (detected)</span>
 		</div>
 		<div transition:slide class="grid grid-cols-1 md:grid-cols-1 lg:grid-cols-2 gap-2">
 			{#each plugins as plugin}


### PR DESCRIPTION
In this way it's more clear to the users that aren't all the plugins but just the one detected by the portal itself.