### PR TITLE
Add color support for shields / badges

### DIFF
--- a/src/routes/[username]/[slug]/badges/leaderkey/+server.ts
+++ b/src/routes/[username]/[slug]/badges/leaderkey/+server.ts
@@ -2,16 +2,23 @@ import { getConfigBySlug } from '$lib/server/prisma/neovimconfigs/service';
 import type { RequestEvent, RequestHandler } from './$types';
 
 const BASE_URL =
-	'https://img.shields.io/badge/{value}-22c55e?logo=neovim&label={label}&labelColor=1e40af&link=https://dotfyle.com/{repo-owner}/{repo-slug}&style={style}';
+	'https://img.shields.io/badge/{value}-{color}?logo=neovim&label={label}&labelColor={label_color}&link=https://dotfyle.com/{repo-owner}/{repo-slug}&style={style}';
 
 export const GET: RequestHandler = async function (event: RequestEvent) {
 	const { username, slug } = event.params;
 	const style = event.url.searchParams.get('style') ?? 'flat';
+
+	// Add color support + sanitize input
+	const color = event.url.searchParams.get('color').replaceAll(/[^0-9a-z]/i, '') ?? '22c55e';
+	const label_color = event.url.searchParams.get('label_color').replaceAll(/[^0-9a-z]/i, '') ?? '1e40af';
+
 	const neovimConfig = await getConfigBySlug(username, slug);
 	const url = BASE_URL.replaceAll('{repo-owner}', username)
 		.replaceAll('{repo-slug}', slug)
 		.replaceAll('{label}', `leaderkey`)
 		.replaceAll('{value}', neovimConfig.leaderkey)
+		.replaceAll('{color}', color)
+		.replaceAll('{label_color}', label_color)
 		.replaceAll('{style}', style);
 	const res = await fetch(url).then((r) => r.text());
 	event.setHeaders({

--- a/src/routes/[username]/[slug]/badges/leaderkey/+server.ts
+++ b/src/routes/[username]/[slug]/badges/leaderkey/+server.ts
@@ -2,7 +2,7 @@ import { getConfigBySlug } from '$lib/server/prisma/neovimconfigs/service';
 import type { RequestEvent, RequestHandler } from './$types';
 
 const BASE_URL =
-	'https://img.shields.io/badge/{value}-{color}?logo=neovim&label={label}&labelColor={label_color}&link=https://dotfyle.com/{repo-owner}/{repo-slug}&style={style}';
+	'https://img.shields.io/badge/{value}-{color}?logo=neovim&label={label}&labelColor={labelColor}&link=https://dotfyle.com/{repo-owner}/{repo-slug}&style={style}';
 
 export const GET: RequestHandler = async function (event: RequestEvent) {
 	const { username, slug } = event.params;
@@ -10,7 +10,7 @@ export const GET: RequestHandler = async function (event: RequestEvent) {
 
 	// Add color support + sanitize input
 	const color = event.url.searchParams.get('color').replaceAll(/[^0-9a-z]/i, '') ?? '22c55e';
-	const label_color = event.url.searchParams.get('label_color').replaceAll(/[^0-9a-z]/i, '') ?? '1e40af';
+	const label_color = event.url.searchParams.get('labelColor').replaceAll(/[^0-9a-z]/i, '') ?? '1e40af';
 
 	const neovimConfig = await getConfigBySlug(username, slug);
 	const url = BASE_URL.replaceAll('{repo-owner}', username)
@@ -18,7 +18,7 @@ export const GET: RequestHandler = async function (event: RequestEvent) {
 		.replaceAll('{label}', `leaderkey`)
 		.replaceAll('{value}', neovimConfig.leaderkey)
 		.replaceAll('{color}', color)
-		.replaceAll('{label_color}', label_color)
+		.replaceAll('{labelColor}', label_color)
 		.replaceAll('{style}', style);
 	const res = await fetch(url).then((r) => r.text());
 	event.setHeaders({

--- a/src/routes/[username]/[slug]/badges/plugin-manager/+server.ts
+++ b/src/routes/[username]/[slug]/badges/plugin-manager/+server.ts
@@ -2,7 +2,7 @@ import { prismaClient } from '$lib/server/prisma/client';
 import type { RequestEvent, RequestHandler } from './$types';
 
 const BASE_URL =
-	'https://img.shields.io/badge/{value}-{color}?logo=neovim&label={label}&labelColor={label_color}&link=https://dotfyle.com/{repo-owner}/{repo-slug}&style={style}';
+	'https://img.shields.io/badge/{value}-{color}?logo=neovim&label={label}&labelColor={labelColor}&link=https://dotfyle.com/{repo-owner}/{repo-slug}&style={style}';
 
 export const GET: RequestHandler = async function (event: RequestEvent) {
 	const { username, slug } = event.params;
@@ -10,7 +10,7 @@ export const GET: RequestHandler = async function (event: RequestEvent) {
 
 	// Add color support + sanitize input
 	const color = event.url.searchParams.get('color').replaceAll(/[^0-9a-z]/i, '') ?? '22c55e';
-	const label_color = event.url.searchParams.get('label_color').replaceAll(/[^0-9a-z]/i, '') ?? '1e40af';
+	const label_color = event.url.searchParams.get('labelColor').replaceAll(/[^0-9a-z]/i, '') ?? '1e40af';
 
 	const pluginManagerInstallation = await prismaClient.neovimConfigPlugins.findFirst({
 		where: {
@@ -33,7 +33,7 @@ export const GET: RequestHandler = async function (event: RequestEvent) {
 		.replaceAll('{label}', `plugin manager`)
 		.replaceAll('{value}', pluginManagerInstallation?.plugin?.name ?? 'unknown')
 		.replaceAll('{color}', color)
-		.replaceAll('{label_color}', label_color)
+		.replaceAll('{labelColor}', label_color)
 		.replaceAll('{style}', style);
 	const res = await fetch(url).then((r) => r.text());
 	event.setHeaders({

--- a/src/routes/[username]/[slug]/badges/plugin-manager/+server.ts
+++ b/src/routes/[username]/[slug]/badges/plugin-manager/+server.ts
@@ -2,11 +2,16 @@ import { prismaClient } from '$lib/server/prisma/client';
 import type { RequestEvent, RequestHandler } from './$types';
 
 const BASE_URL =
-	'https://img.shields.io/badge/{value}-22c55e?logo=neovim&label={label}&labelColor=1e40af&link=https://dotfyle.com/{repo-owner}/{repo-slug}&style={style}';
+	'https://img.shields.io/badge/{value}-{color}?logo=neovim&label={label}&labelColor={label_color}&link=https://dotfyle.com/{repo-owner}/{repo-slug}&style={style}';
 
 export const GET: RequestHandler = async function (event: RequestEvent) {
 	const { username, slug } = event.params;
 	const style = event.url.searchParams.get('style') ?? 'flat';
+
+	// Add color support + sanitize input
+	const color = event.url.searchParams.get('color').replaceAll(/[^0-9a-z]/i, '') ?? '22c55e';
+	const label_color = event.url.searchParams.get('label_color').replaceAll(/[^0-9a-z]/i, '') ?? '1e40af';
+
 	const pluginManagerInstallation = await prismaClient.neovimConfigPlugins.findFirst({
 		where: {
 			config: {
@@ -27,6 +32,8 @@ export const GET: RequestHandler = async function (event: RequestEvent) {
 		.replaceAll('{repo-slug}', slug)
 		.replaceAll('{label}', `plugin manager`)
 		.replaceAll('{value}', pluginManagerInstallation?.plugin?.name ?? 'unknown')
+		.replaceAll('{color}', color)
+		.replaceAll('{label_color}', label_color)
 		.replaceAll('{style}', style);
 	const res = await fetch(url).then((r) => r.text());
 	event.setHeaders({

--- a/src/routes/[username]/[slug]/badges/plugins/+server.ts
+++ b/src/routes/[username]/[slug]/badges/plugins/+server.ts
@@ -2,7 +2,7 @@ import { getConfigBySlug } from '$lib/server/prisma/neovimconfigs/service';
 import type { RequestEvent, RequestHandler } from './$types';
 
 const BASE_URL =
-	'https://img.shields.io/badge/{value}-{color}?logo=neovim&label={label}&labelColor={label_color}&link=https://dotfyle.com/{repo-owner}/{repo-slug}&style={style}';
+	'https://img.shields.io/badge/{value}-{color}?logo=neovim&label={label}&labelColor={labelColor}&link=https://dotfyle.com/{repo-owner}/{repo-slug}&style={style}';
 
 export const GET: RequestHandler = async function (event: RequestEvent) {
 	const { username, slug } = event.params;
@@ -10,7 +10,7 @@ export const GET: RequestHandler = async function (event: RequestEvent) {
 
 	// Add color support + sanitize input
 	const color = event.url.searchParams.get('color').replaceAll(/[^0-9a-z]/i, '') ?? '22c55e';
-	const label_color = event.url.searchParams.get('label_color').replaceAll(/[^0-9a-z]/i, '') ?? '1e40af';
+	const label_color = event.url.searchParams.get('labelColor').replaceAll(/[^0-9a-z]/i, '') ?? '1e40af';
 
 	const neovimConfig = await getConfigBySlug(username, slug);
 	const pluginCount = neovimConfig.pluginCount;
@@ -19,7 +19,7 @@ export const GET: RequestHandler = async function (event: RequestEvent) {
 		.replaceAll('{label}', `plugins installed`)
 		.replaceAll('{value}', pluginCount.toString())
 		.replaceAll('{color}', color)
-		.replaceAll('{label_color}', label_color)
+		.replaceAll('{labelColor}', label_color)
 		.replaceAll('{style}', style);
 	const res = await fetch(url).then((r) => r.text());
 	event.setHeaders({

--- a/src/routes/[username]/[slug]/badges/plugins/+server.ts
+++ b/src/routes/[username]/[slug]/badges/plugins/+server.ts
@@ -2,17 +2,24 @@ import { getConfigBySlug } from '$lib/server/prisma/neovimconfigs/service';
 import type { RequestEvent, RequestHandler } from './$types';
 
 const BASE_URL =
-	'https://img.shields.io/badge/{value}-22c55e?logo=neovim&label={label}&labelColor=1e40af&link=https://dotfyle.com/{repo-owner}/{repo-slug}&style={style}';
+	'https://img.shields.io/badge/{value}-{color}?logo=neovim&label={label}&labelColor={label_color}&link=https://dotfyle.com/{repo-owner}/{repo-slug}&style={style}';
 
 export const GET: RequestHandler = async function (event: RequestEvent) {
 	const { username, slug } = event.params;
 	const style = event.url.searchParams.get('style') ?? 'flat';
+
+	// Add color support + sanitize input
+	const color = event.url.searchParams.get('color').replaceAll(/[^0-9a-z]/i, '') ?? '22c55e';
+	const label_color = event.url.searchParams.get('label_color').replaceAll(/[^0-9a-z]/i, '') ?? '1e40af';
+
 	const neovimConfig = await getConfigBySlug(username, slug);
 	const pluginCount = neovimConfig.pluginCount;
 	const url = BASE_URL.replaceAll('{repo-owner}', username)
 		.replaceAll('repo-slug', slug)
 		.replaceAll('{label}', `plugins installed`)
 		.replaceAll('{value}', pluginCount.toString())
+		.replaceAll('{color}', color)
+		.replaceAll('{label_color}', label_color)
 		.replaceAll('{style}', style);
 	const res = await fetch(url).then((r) => r.text());
 	event.setHeaders({

--- a/src/routes/plugins/[owner]/[plugin]/shield/+server.ts
+++ b/src/routes/plugins/[owner]/[plugin]/shield/+server.ts
@@ -2,16 +2,22 @@ import { getPlugin } from '$lib/server/prisma/neovimplugins/service';
 import type { RequestEvent, RequestHandler } from './$types';
 
 const BASE_URL =
-	'https://img.shields.io/badge/{plugin-usage}-22c55e?logo=neovim&label=configs%20using%20{repo-name}&labelColor=1e40af&link=https://dotfyle.com/plugins/{repo-owner}/{repo-name}&style={style}';
+	'https://img.shields.io/badge/{plugin-usage}-{color}?logo=neovim&label=configs%20using%20{repo-name}&labelColor={label_color}&link=https://dotfyle.com/plugins/{repo-owner}/{repo-name}&style={style}';
 
 export const GET: RequestHandler = async function (event: RequestEvent) {
 	const { owner, plugin: plugin } = event.params;
 	const style = event.url.searchParams.get('style') ?? 'flat';
+	
+	// Add color support + sanitize input
+	const color = event.url.searchParams.get('color').replaceAll(/[^0-9a-z]/i, '') ?? '22c55e';
+	const label_color = event.url.searchParams.get('label_color').replaceAll(/[^0-9a-z]/i, '') ?? '1e40af';
+	
 	const neovimPlugin = await getPlugin(owner, plugin);
 	const usage = neovimPlugin.configCount;
 	const url = BASE_URL.replaceAll('{repo-owner}', owner)
 		.replaceAll('{repo-name}', plugin)
 		.replaceAll('{plugin-usage}', usage.toString())
+		.replaceAll('{color}', color)
 		.replaceAll('{style}', style);
 	const res = await fetch(url).then((r) => r.text());
 	event.setHeaders({

--- a/src/routes/plugins/[owner]/[plugin]/shield/+server.ts
+++ b/src/routes/plugins/[owner]/[plugin]/shield/+server.ts
@@ -7,17 +7,18 @@ const BASE_URL =
 export const GET: RequestHandler = async function (event: RequestEvent) {
 	const { owner, plugin: plugin } = event.params;
 	const style = event.url.searchParams.get('style') ?? 'flat';
-	
+
 	// Add color support + sanitize input
 	const color = event.url.searchParams.get('color').replaceAll(/[^0-9a-z]/i, '') ?? '22c55e';
 	const label_color = event.url.searchParams.get('label_color').replaceAll(/[^0-9a-z]/i, '') ?? '1e40af';
-	
+
 	const neovimPlugin = await getPlugin(owner, plugin);
 	const usage = neovimPlugin.configCount;
 	const url = BASE_URL.replaceAll('{repo-owner}', owner)
 		.replaceAll('{repo-name}', plugin)
 		.replaceAll('{plugin-usage}', usage.toString())
 		.replaceAll('{color}', color)
+		.replaceAll('{label_color}', label_color)
 		.replaceAll('{style}', style);
 	const res = await fetch(url).then((r) => r.text());
 	event.setHeaders({

--- a/src/routes/plugins/[owner]/[plugin]/shield/+server.ts
+++ b/src/routes/plugins/[owner]/[plugin]/shield/+server.ts
@@ -2,7 +2,7 @@ import { getPlugin } from '$lib/server/prisma/neovimplugins/service';
 import type { RequestEvent, RequestHandler } from './$types';
 
 const BASE_URL =
-	'https://img.shields.io/badge/{plugin-usage}-{color}?logo=neovim&label=configs%20using%20{repo-name}&labelColor={label_color}&link=https://dotfyle.com/plugins/{repo-owner}/{repo-name}&style={style}';
+	'https://img.shields.io/badge/{plugin-usage}-{color}?logo=neovim&label=configs%20using%20{repo-name}&labelColor={labelColor}&link=https://dotfyle.com/plugins/{repo-owner}/{repo-name}&style={style}';
 
 export const GET: RequestHandler = async function (event: RequestEvent) {
 	const { owner, plugin: plugin } = event.params;
@@ -10,7 +10,7 @@ export const GET: RequestHandler = async function (event: RequestEvent) {
 
 	// Add color support + sanitize input
 	const color = event.url.searchParams.get('color').replaceAll(/[^0-9a-z]/i, '') ?? '22c55e';
-	const label_color = event.url.searchParams.get('label_color').replaceAll(/[^0-9a-z]/i, '') ?? '1e40af';
+	const label_color = event.url.searchParams.get('labelColor').replaceAll(/[^0-9a-z]/i, '') ?? '1e40af';
 
 	const neovimPlugin = await getPlugin(owner, plugin);
 	const usage = neovimPlugin.configCount;
@@ -18,7 +18,7 @@ export const GET: RequestHandler = async function (event: RequestEvent) {
 		.replaceAll('{repo-name}', plugin)
 		.replaceAll('{plugin-usage}', usage.toString())
 		.replaceAll('{color}', color)
-		.replaceAll('{label_color}', label_color)
+		.replaceAll('{labelColor}', label_color)
 		.replaceAll('{style}', style);
 	const res = await fetch(url).then((r) => r.text());
 	event.setHeaders({


### PR DESCRIPTION
Add sanitizes input URI arguments for `color`, `logoColor` and `labelColor`, allowing users to customize their shields.

e.g. :
```html
<img src="https://dotfyle.com/plugins/Makaze/watch.nvim/shield?style=flat&color=45aa67&labelColor=222222&logoColor=aaaaaa" />
```
Which becomes:
<img src="https://img.shields.io/badge/2-45aa67?logo=neovim&label=configs%20using%20watch.nvim&style=flat&labelColor=222222&logoColor=aaaaaa" />