### PR TITLE
Add TaDaa/vimade

### DIFF
--- a/SUBMITTED-PLUGINS.md
+++ b/SUBMITTED-PLUGINS.md
@@ -66,6 +66,7 @@
 ## Color
 
 - echasnovski/mini.hipatterns
+- TaDaa/vimade
 
 ## Colorscheme
 


### PR DESCRIPTION
Hi @codicocodes,

I just saw your site and it looks great! 

I'm hoping to add https://github.com/TaDaa/vimade as its been updated to support a Lua only code path.   I'm not able to use the form because the python logic that supports Neovim < 0.8 and Vim is weighing down the language %.
 
---
edit I'm not sure this is the right way to go about manually adding a plugin or not, if its not please let me know
 
 Thank you!