### PR TITLE
add ruff to lsp list

### DIFF
--- a/src/lib/server/nvim-sync/config/LanguageServerFinder.ts
+++ b/src/lib/server/nvim-sync/config/LanguageServerFinder.ts
@@ -179,6 +179,7 @@ export const KNOWN_LANGUAGE_SERVERS = [
   'rome',
   'ruby_ls',
   'ruff_lsp',
+  'ruff',
   'rust_analyzer',
   'salt_ls',
   'scheme_langserver',


### PR DESCRIPTION
[ruff-lsp](https://github.com/astral-sh/ruff-lsp) is deprecated now. 
Now in use just [ruff](https://github.com/astral-sh/ruff)