### PR TITLE
feat: deterministic plugin cover image via README order

### DIFF
--- a/prisma/migrations/20260717210019_add_position_to_media/migration.sql
+++ b/prisma/migrations/20260717210019_add_position_to_media/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Media" ADD COLUMN     "position" INTEGER;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -179,6 +179,7 @@ model Media {
   url            String        @unique
   type           String        @default("")
   thumbnail      Boolean       @default(false)
+  position       Int?
   NeovimPlugin   NeovimPlugin? @relation(fields: [neovimPluginId], references: [id])
   neovimPluginId Int?
 }

--- a/src/lib/server/media/parser.spec.ts
+++ b/src/lib/server/media/parser.spec.ts
@@ -120,4 +120,17 @@ describe('GithubMediaParser.findMediaUrls()', () => {
     const media = run(md, 'MunifTanjim', 'nui.nvim', 'main');
     expect(media[0]).toEqual(output);
   });
+
+  // Group-priority order: absolute url emitted before an earlier relative one.
+  it('emits by source group, not document position', () => {
+    const readme = [
+      '![relative first](./assets/a.png)',
+      '![absolute second](https://raw.githubusercontent.com/me/repo/main/b.png)'
+    ].join('\n');
+    const media = run(readme, 'me', 'repo', 'main');
+    expect(media).toEqual([
+      'https://raw.githubusercontent.com/me/repo/main/b.png',
+      'https://raw.githubusercontent.com/me/repo/main/assets/a.png'
+    ]);
+  });
 });

--- a/src/lib/server/media/parser.ts
+++ b/src/lib/server/media/parser.ts
@@ -26,6 +26,7 @@ export class GithubMediaParser {
   }
 
   findMediaUrls(readme: string, user: string, repo: string, branch: string): string[] {
+    // URLs are emitted grouped by source type below, not strict README order.
     const validGithubLinkRegex =
       /https:\/\/(raw|user-images).githubusercontent.com\/[a-zA-Z0-9/]+\/[a-zA-Z0-9/\-._]+.(png|jpg|jpeg|mp4|gif)/g;
 

--- a/src/lib/server/prisma/media/service.ts
+++ b/src/lib/server/prisma/media/service.ts
@@ -1,4 +1,13 @@
+import type { Prisma } from '@prisma/client';
 import { prismaClient } from '../client';
+
+// Cover-image ordering: manual thumbnail flag first, then README order
+// (position; legacy rows have null position and sort last), then id for stability.
+export const mediaCoverOrderBy: Prisma.MediaOrderByWithRelationInput[] = [
+  { thumbnail: 'desc' },
+  { position: { sort: 'asc', nulls: 'last' } },
+  { id: 'asc' }
+];
 
 export async function getMediaForPlugin(owner: string, name: string) {
   return prismaClient.media.findMany({
@@ -7,6 +16,7 @@ export async function getMediaForPlugin(owner: string, name: string) {
         owner,
         name
       }
-    }
+    },
+    orderBy: mediaCoverOrderBy
   });
 }

--- a/src/lib/server/prisma/neovimplugins/service.ts
+++ b/src/lib/server/prisma/neovimplugins/service.ts
@@ -1,6 +1,7 @@
 import { daysAgo } from '$lib/utils';
 import type { NeovimPlugin } from '@prisma/client';
 import { prismaClient } from '../client';
+import { mediaCoverOrderBy } from '../media/service';
 import { paginator, type PaginatedResult } from '../pagination';
 import type {
   NeovimPluginIdentifier,
@@ -132,9 +133,7 @@ const selectConfigCount = {
   addedLastWeek: true,
   dotfyleShieldAddedAt: true,
   media: {
-    orderBy: {
-      thumbnail: 'desc'
-    }
+    orderBy: mediaCoverOrderBy
   },
   _count: {
     select: {

--- a/src/lib/server/rss/plugins.ts
+++ b/src/lib/server/rss/plugins.ts
@@ -1,5 +1,6 @@
 import RSS from 'rss';
 import { prismaClient } from '$lib/server/prisma/client';
+import { mediaCoverOrderBy } from '$lib/server/prisma/media/service';
 import { marked } from 'marked';
 import { getMediaType, sanitizeHtml } from '$lib/utils';
 import fs from 'fs';
@@ -14,9 +15,7 @@ export async function createPluginsRssFeed() {
   const plugins = await prismaClient.neovimPlugin.findMany({
     include: {
       media: {
-        orderBy: {
-          thumbnail: 'desc'
-        }
+        orderBy: mediaCoverOrderBy
       }
     },
     orderBy: {

--- a/src/lib/server/sync/plugins/mediaOrder.ts
+++ b/src/lib/server/sync/plugins/mediaOrder.ts
@@ -1,8 +1,7 @@
 /**
- * Assign each media URL its position in README order, deduping by URL and
- * keeping the first occurrence. The parser returns URLs in the order they
- * appear; this position becomes the tiebreaker for choosing the cover image
- * so the first image in the README wins by default.
+ * Assign each media URL its position, deduping by URL and keeping the first
+ * occurrence. Position tiebreaks cover selection; it follows the parser's emit
+ * order — grouped by source type, not strict README order. See PR #202.
  */
 export function orderedUniqueMedia(urls: string[]): { url: string; position: number }[] {
   const seen = new Set<string>();

--- a/src/lib/server/sync/plugins/mediaOrder.ts
+++ b/src/lib/server/sync/plugins/mediaOrder.ts
@@ -1,0 +1,16 @@
+/**
+ * Assign each media URL its position in README order, deduping by URL and
+ * keeping the first occurrence. The parser returns URLs in the order they
+ * appear; this position becomes the tiebreaker for choosing the cover image
+ * so the first image in the README wins by default.
+ */
+export function orderedUniqueMedia(urls: string[]): { url: string; position: number }[] {
+  const seen = new Set<string>();
+  const ordered: { url: string; position: number }[] = [];
+  for (const url of urls) {
+    if (seen.has(url)) continue;
+    seen.add(url);
+    ordered.push({ url, position: ordered.length });
+  }
+  return ordered;
+}

--- a/src/lib/server/sync/plugins/sync.spec.ts
+++ b/src/lib/server/sync/plugins/sync.spec.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Only I/O is stubbed: the DB write and the network fetch. The parser and the
+// position logic run for real, so this exercises the actual sync behaviour.
+const { upsert } = vi.hoisted(() => ({ upsert: vi.fn() }));
+vi.mock('$lib/server/prisma/client', () => ({
+  prismaClient: { media: { upsert } }
+}));
+
+import { PluginSyncer } from './sync';
+
+const README = `
+# cool.nvim
+
+A tidy colorscheme.
+
+![banner](./media/banner.png)
+
+## Screenshots
+
+![editor](./media/editor.png)
+
+![telescope](./media/telescope.png)
+
+And the banner once more: ![banner](./media/banner.png)
+`;
+
+function syncReadme(readme: string) {
+  const plugin = { id: 7, owner: 'me', name: 'cool.nvim', configCount: 0, media: [] };
+  // token/repo are unused by the media path beyond the default branch
+  return new PluginSyncer('token', plugin as never).syncMedia(readme, {
+    default_branch: 'main'
+  } as never);
+}
+
+const persisted = () => upsert.mock.calls.map((c) => c[0].create);
+const row = (frag: string) => persisted().find((m) => m.url.endsWith(frag));
+
+beforeEach(() => {
+  upsert.mockReset();
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async () => ({ headers: { get: () => 'image/png' }, status: 200, statusText: 'OK' }))
+  );
+});
+
+describe('syncMedia — README image ordering', () => {
+  it('stores the first README image as the cover (position 0), the rest in order', async () => {
+    await syncReadme(README);
+
+    expect(row('/media/banner.png')?.position).toBe(0);
+    expect(row('/media/editor.png')?.position).toBe(1);
+    expect(row('/media/telescope.png')?.position).toBe(2);
+  });
+
+  it('collapses a repeated image to one row and keeps its first position', async () => {
+    await syncReadme(README);
+
+    const banners = persisted().filter((m) => m.url.endsWith('/media/banner.png'));
+    expect(banners).toHaveLength(1);
+    expect(banners[0].position).toBe(0);
+    expect(persisted()).toHaveLength(3);
+  });
+
+  it('resolves relative paths against the repo raw URL', async () => {
+    await syncReadme(README);
+
+    expect(row('/media/banner.png')?.url).toBe(
+      'https://raw.githubusercontent.com/me/cool.nvim/main/media/banner.png'
+    );
+  });
+
+  it('never writes the thumbnail flag, so a manual cover choice survives re-sync', async () => {
+    await syncReadme(README);
+
+    for (const call of upsert.mock.calls) {
+      expect(call[0].create).not.toHaveProperty('thumbnail');
+      expect(call[0].update).not.toHaveProperty('thumbnail');
+    }
+  });
+});

--- a/src/lib/server/sync/plugins/sync.ts
+++ b/src/lib/server/sync/plugins/sync.ts
@@ -6,6 +6,7 @@ import { prismaClient } from '$lib/server/prisma/client';
 import type { NeovimPluginWithCount } from '$lib/server/prisma/neovimplugins/schema';
 import { getPlugin, updatePlugin } from '$lib/server/prisma/neovimplugins/service';
 import { getGithubToken } from '$lib/server/prisma/users/service';
+import { orderedUniqueMedia } from './mediaOrder';
 import { daysAgo, hasBeenOneDay, isAdmin } from '$lib/utils';
 import type { NeovimPlugin, User } from '@prisma/client';
 import { TRPCError } from '@trpc/server';
@@ -62,46 +63,44 @@ export class PluginSyncer {
   }
 
   async syncMedia(readme: string, repo: GithubRepository) {
-    const media = this.mediaParser.findMediaUrls(
+    const urls = this.mediaParser.findMediaUrls(
       readme,
       this.plugin.owner,
       this.plugin.name,
       repo.default_branch
     );
     const data = await Promise.all(
-      media.map(async (url) => {
-        return fetch(url).then((r) => {
-          const type = r.headers.get('Content-Type') ?? '';
-          if (!type) {
-            console.log(`missing Content-Type for ${url}`, {
-              owner: this.plugin.owner,
-              name: this.plugin.name,
-              status: r.status,
-              statusText: r.statusText
-            });
-          }
-          return {
-            url,
-            type,
-            neovimPluginId: this.plugin.id
-          };
-        });
+      orderedUniqueMedia(urls).map(async ({ url, position }) => {
+        const r = await fetch(url);
+        const type = r.headers.get('Content-Type') ?? '';
+        if (!type) {
+          console.log(`missing Content-Type for ${url}`, {
+            owner: this.plugin.owner,
+            name: this.plugin.name,
+            status: r.status,
+            statusText: r.statusText
+          });
+        }
+        return {
+          url,
+          type,
+          position,
+          neovimPluginId: this.plugin.id
+        };
       })
     );
 
     // TODO: 1. allow multiple plugins per media url
     // TODO: 2. Remove stale media
-    await Promise.all([
-      data.map(async (m) => {
-        return await prismaClient.media.upsert({
-          where: {
-            url: m.url
-          },
+    await Promise.all(
+      data.map((m) =>
+        prismaClient.media.upsert({
+          where: { url: m.url },
           create: m,
           update: m
-        });
-      })
-    ]);
+        })
+      )
+    );
   }
 
   syncHasDotfyleShield(readme: string) {


### PR DESCRIPTION
👋 First off — I'm a big fan of dotfyle and really appreciate everything you've built for the Neovim community. This one started as a small personal itch: my colorscheme's thumbnail on dotfyle was showing the wrong image, and digging into *why* turned into this PR.

## What

Plugin cover image is random when a README has multiple images. Media is ordered only by `orderBy: { thumbnail: 'desc' }` — with no thumbnail set every row ties, so Postgres returns them in arbitrary heap order and the cover (and og:image) is whatever lands at index 0.

Adds a `position` column set to each image's index in the parser's output during sync, and orders by it. Cover now defaults to the **first image the parser emits** (see caveat below). The manual `thumbnail` flag still wins.

Fixes #186. Also addresses the ordering half of #136.

## Why

- **#186** — cover picked at random (an author reported the 17th README image used as cover); non-admin authors can't control it.
- **#136** — gallery images shown out of order.

## How

- `Media.position Int?` — nullable, additive migration.
- `syncMedia` writes the parser index, deduped by URL keeping the first occurrence.
- One shared `mediaCoverOrderBy` = `[{ thumbnail: desc }, { position: asc, nulls: last }, { id: asc }]`, used by the plugin page, RSS feed, and the media endpoint.
- Drive-by: `syncMedia` upserts were wrapped in an extra array (`Promise.all([arr.map(...)])`) and never awaited — fixed.

## Ordering caveat — group order, not strict document order

`position` follows the order `findMediaUrls` emits URLs, which groups by source type (absolute `githubusercontent` > `/assets` uploads > relative markdown > relative HTML) and is document-ordered only *within* a group. So the cover is the first image of the **highest-priority group present** — e.g. a markdown screenshot can outrank an `<img>` banner placed above it.

Kept as-is on purpose. This preserves the parser's existing emit order, which predates test coverage and has no documented rationale (matcher flagged for refactor in #97). The real win here is **determinism** — same cover every sync, authors can influence it by ordering their README — not literal document order. True document order is a small follow-up (sort parser matches on their string index); happy to add it if you'd prefer that behavior.

## Self-heals existing plugins, no stale-media delete

Rows dropped from a README but never re-synced keep `position = null` and sort **last**, so the correct cover surfaces on the next weekly sync **without deleting anything**. This deliberately avoids the `deleteMany` path from #140 that crashed the seeder. Stale-media cleanup (#128) stays a separate issue.

## Not included

- Stale-media removal (#128).
- Parser regex changes — #143 is in flight in `parser.ts`; this PR doesn't touch it.
- True README document order (see caveat) — deliberately deferred.
- Using the GitHub social-preview image as cover (#186 comment) — possible follow-up.

## Test

`sync.spec.ts` — drives the real `syncMedia` + real parser against a multi-image README, stubbing only `fetch` and the DB `upsert` (no DB, no network, matches the existing `vi.mock` test style). Asserts: first README image → position 0, repeats collapse to one row keeping first position, relative paths resolve to raw URLs, and the `thumbnail` flag is never written so a manual cover choice survives re-sync.

`parser.spec.ts` — adds a case pinning the group-priority emit order (an absolute URL is emitted before a relative one that appears earlier in the README), so the caveat above is locked in and a future rework has to update it consciously.
